### PR TITLE
Fix mark all as read btn behavior

### DIFF
--- a/app/controllers/api/mail_applications_controller.rb
+++ b/app/controllers/api/mail_applications_controller.rb
@@ -1,11 +1,11 @@
 class Api::MailApplicationsController < Api::ProtectedApplicationController
 
   def mark_all_messages_as_read
-    @application = available_applications.find(params[:id])
-    @messages = @application.mail_messages
-    @messages.each { |m| m.mark_read }
+    application = available_applications.find(params[:id])
+    messages = application.mail_messages
+    messages.each { |m| m.mark_read }
 
-    respond_with @messages
+    respond_with :status => :ok
   end
 
   private

--- a/app/controllers/api/mail_applications_controller.rb
+++ b/app/controllers/api/mail_applications_controller.rb
@@ -1,0 +1,16 @@
+class Api::MailApplicationsController < Api::ProtectedApplicationController
+
+  def mark_all_messages_as_read
+    @application = available_applications.find(params[:id])
+    @messages = @application.mail_messages
+    @messages.each { |m| m.mark_read }
+
+    respond_with @messages
+  end
+
+  private
+
+    def available_applications
+      current_user.available_applications
+    end
+end

--- a/app/controllers/api/mail_messages_controller.rb
+++ b/app/controllers/api/mail_messages_controller.rb
@@ -1,6 +1,6 @@
-class Api::MailMessagesController < Api::ApplicationController
+class Api::MailMessagesController < Api::ProtectedApplicationController
   #TODO: auth for SMTP server
-  before_filter :authenticate_user!, :except => :create
+  skip_before_filter :authenticate_user!, :only => :create
 
   def create
     @application = auth_application(params[:message][:user], params[:message][:password])

--- a/app/controllers/api/mail_messages_controller.rb
+++ b/app/controllers/api/mail_messages_controller.rb
@@ -27,13 +27,6 @@ class Api::MailMessagesController < Api::ApplicationController
     respond_with @message
   end
 
-  def mark_all_as_read
-    @messages = available_applications_messages.all
-    @messages.each { |m| m.mark_read }
-
-    respond_with @messages
-  end
-
   protected
 
     def auth_application(name, password)

--- a/app/helpers/api/mail_messages_helper.rb
+++ b/app/helpers/api/mail_messages_helper.rb
@@ -1,2 +1,0 @@
-module Api::MailMessagesHelper
-end

--- a/app/helpers/web/mail_messages_helper.rb
+++ b/app/helpers/web/mail_messages_helper.rb
@@ -1,2 +1,0 @@
-module Web::MailMessagesHelper
-end

--- a/app/helpers/web/user/facebook_helper.rb
+++ b/app/helpers/web/user/facebook_helper.rb
@@ -1,2 +1,0 @@
-module Web::User::FacebookHelper
-end

--- a/app/helpers/web/user/github_helper.rb
+++ b/app/helpers/web/user/github_helper.rb
@@ -1,2 +1,0 @@
-module Web::User::GithubHelper
-end

--- a/app/helpers/web/user/networks_helper.rb
+++ b/app/helpers/web/user/networks_helper.rb
@@ -1,2 +1,0 @@
-module Web::User::NetworksHelper
-end

--- a/app/helpers/web/welcome_helper.rb
+++ b/app/helpers/web/welcome_helper.rb
@@ -1,2 +1,0 @@
-module Web::WelcomeHelper
-end

--- a/app/views/web/mail_applications/show.html.haml
+++ b/app/views/web/mail_applications/show.html.haml
@@ -24,7 +24,7 @@
     %i.icon-ok
     = t("read_selected")
 
-  = link_to mark_all_as_read_api_mail_messages_path,
+  = link_to mark_all_messages_as_read_api_mail_application_path(@application),
     :class => "btn btn-success mark_all_as_read", :method => :put, :remote => true do
     %i.icon-ok
     = t("mark_all_as_read")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,10 @@ MailSandboxWeb::Application.routes.draw do
       member do
         put :mark_read
       end
-      collection do
-        put :mark_all_as_read
+    end
+    resources :mail_applications, :only => [] do
+      member do
+        put :mark_all_messages_as_read
       end
     end
   end

--- a/test/functional/api/mail_applications_controller_test.rb
+++ b/test/functional/api/mail_applications_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class Api::MailApplicationsControllerTest < ActionController::TestCase
+
+  setup do
+    @user = create :facebook_user
+    sign_in @user
+
+    @my_application = create :application, :owner => @user
+  end
+
+  test "should mark all as read" do
+    messages = create_list :mail_message, 2, :mail_application => @my_application
+
+    put :mark_all_messages_as_read, :id => @my_application.id, :format => :json
+    assert_response :success
+
+    message = messages.first
+    message.reload
+    assert message.read?
+  end
+end

--- a/test/functional/api/mail_messages_controller_test.rb
+++ b/test/functional/api/mail_messages_controller_test.rb
@@ -62,15 +62,4 @@ class Api::MailMessagesControllerTest < ActionController::TestCase
     message.reload
     assert !message.deleted?
   end
-
-  test "should mark all as read" do
-    messages = create_list :mail_message, 2, :mail_application => @my_application
-
-    put :mark_all_as_read, :format => :json
-    assert_response :success
-
-    message = messages.first
-    message.reload
-    assert message.read?
-  end
 end

--- a/test/unit/helpers/api/mail_messages_helper_test.rb
+++ b/test/unit/helpers/api/mail_messages_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Api::MailMessagesHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/web/mail_messages_helper_test.rb
+++ b/test/unit/helpers/web/mail_messages_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Web::MailMessagesHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/web/user/facebook_helper_test.rb
+++ b/test/unit/helpers/web/user/facebook_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Web::User::FacebookHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/web/user/github_helper_test.rb
+++ b/test/unit/helpers/web/user/github_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Web::User::GithubHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/web/user/networks_helper_test.rb
+++ b/test/unit/helpers/web/user/networks_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Web::User::NetworksHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/web/welcome_helper_test.rb
+++ b/test/unit/helpers/web/welcome_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Web::WelcomeHelperTest < ActionView::TestCase
-end


### PR DESCRIPTION
Now mark all as read btn should mark only application messages. Also I've made a couple refactorings.
